### PR TITLE
migrate costmap_cspace_msgs

### DIFF
--- a/costmap_cspace_msgs/CMakeLists.txt
+++ b/costmap_cspace_msgs/CMakeLists.txt
@@ -1,18 +1,19 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.14.4)
 project(costmap_cspace_msgs)
 
-set(MESSAGE_DEPENDS
-  geometry_msgs
-  std_msgs
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/CSpace3D.msg
+  msg/CSpace3DUpdate.msg
+  msg/MapMetaData3D.msg
+  DEPENDENCIES geometry_msgs std_msgs
 )
 
-find_package(catkin REQUIRED COMPONENTS message_generation ${MESSAGE_DEPENDS})
-
-add_message_files(
-  FILES
-    CSpace3D.msg
-    CSpace3DUpdate.msg
-    MapMetaData3D.msg
-)
-generate_messages(DEPENDENCIES ${MESSAGE_DEPENDS})
-catkin_package(CATKIN_DEPENDS message_runtime ${MESSAGE_DEPENDS})
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/costmap_cspace_msgs/msg/CSpace3D.msg
+++ b/costmap_cspace_msgs/msg/CSpace3D.msg
@@ -1,4 +1,4 @@
-Header header 
+std_msgs/Header header 
 
 MapMetaData3D info
 

--- a/costmap_cspace_msgs/msg/CSpace3DUpdate.msg
+++ b/costmap_cspace_msgs/msg/CSpace3DUpdate.msg
@@ -1,4 +1,4 @@
-Header header 
+std_msgs/Header header 
 
 uint32 x
 uint32 y

--- a/costmap_cspace_msgs/package.xml
+++ b/costmap_cspace_msgs/package.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>costmap_cspace_msgs</name>
   <version>0.14.0</version>
   <description>Message definitions for costmap_cspace package</description>
 
-  <maintainer email="atsushi.w@ieee.org">Atsushi Watanabe</maintainer>
+  <maintainer email="tomohiro.oku@gmail.com">Tomohiro Oku</maintainer>
   <license>BSD</license>
   <author email="atsushi.w@ieee.org">Atsushi Watanabe</author>
+  <author email="tomohiro.oku@gmail.com">Tomohiro Oku</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## Issues

- Closed #1

## Features

Migrated costmap_cspace_msgs into ROS 2 Humble.

## Tests

```sh
$ ros2 interface show costmap_cspace_msgs/msg/CSpace3D
std_msgs/Header header
        builtin_interfaces/Time stamp
                int32 sec
                uint32 nanosec
        string frame_id

MapMetaData3D info
        float32 linear_resolution
        float32 angular_resolution
        uint32 width
        uint32 height
        uint32 angle
        geometry_msgs/Pose origin
                Point position
                        float64 x
                        float64 y
                        float64 z
                Quaternion orientation
                        float64 x 0
                        float64 y 0
                        float64 z 0
                        float64 w 1

int8[] data
```

```sh
$ ros2 interface show costmap_cspace_msgs/msg/CSpace3DUpdate 
std_msgs/Header header
        builtin_interfaces/Time stamp
                int32 sec
                uint32 nanosec
        string frame_id

uint32 x
uint32 y
uint32 yaw

uint32 width
uint32 height
uint32 angle

int8[] data
```

```sh
$ ros2 interface show costmap_cspace_msgs/msg/MapMetaData3D 
float32 linear_resolution
float32 angular_resolution

uint32 width
uint32 height
uint32 angle

geometry_msgs/Pose origin
        Point position
                float64 x
                float64 y
                float64 z
        Quaternion orientation
                float64 x 0
                float64 y 0
                float64 z 0
                float64 w 1
```