### PR TITLE
[ROS2] migrate trajectory_tracker_msgs

### DIFF
--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(PKG ${MESSAGE_DEPENDS})
   find_package(${PKG} REQUIRED)
 endforeach()
 
-rosidl_generate_interfaces(
+rosidl_generate_interfaces(${PROJECT_NAME}
   srv/ChangePath.srv
   msg/PathWithVelocity.msg
   msg/PoseStampedWithVelocity.msg

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -25,6 +25,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 ament_export_dependencies(rosidl_default_runtime)
 
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+ament_export_include_directories()
+
 # if(CATKIN_ENABLE_TESTING)
 # set(THREADS_PREFER_PTHREAD_FLAG ON)
 # find_package(Threads REQUIRED)

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -25,18 +25,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 )
 ament_export_dependencies(rosidl_default_runtime)
 
-install(DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME}
-)
-ament_export_include_directories()
-
 if (BUILD_TESTING)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_path_with_velocity_conversion test/src/test_path_with_velocity_conversion.cpp)
-  
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -50,8 +45,14 @@ if (BUILD_TESTING)
   )
 
   target_link_libraries(test_path_with_velocity_conversion
-    rclcpp::rclcpp ${geometry_msgs_TARGETS} ${nav_msgs_TARGETS} ${std_msgs_TARGETS} ${cpp_typesupport_target}
+    rclcpp::rclcpp ${geometry_msgs_TARGETS} ${std_msgs_TARGETS} ${nav_msgs_TARGETS} ${cpp_typesupport_target}
   )
+
 endif()
+
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+ament_export_include_directories()
 
 ament_package()

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -35,9 +35,7 @@ if (BUILD_TESTING)
   find_package(Threads REQUIRED)
 
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(test_path_with_velocity_conversion 
-    test/src/test_path_with_velocity_conversion.cpp
-  )
+  ament_add_gtest(test_path_with_velocity_conversion test/src/test_path_with_velocity_conversion.cpp)
   
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -30,24 +30,30 @@ install(DIRECTORY include/
 )
 ament_export_include_directories()
 
-# if(CATKIN_ENABLE_TESTING)
-# set(THREADS_PREFER_PTHREAD_FLAG ON)
-# find_package(Threads REQUIRED)
+if (BUILD_TESTING)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
 
-# find_package(roscpp REQUIRED)
-# find_package(rosunit REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_path_with_velocity_conversion 
+    test/src/test_path_with_velocity_conversion.cpp
+  )
+  
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
-# add_compile_options(-std=c++11)
+  target_include_directories(test_path_with_velocity_conversion PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
 
-# catkin_add_gtest(test_path_with_velocity_conversion test/src/test_path_with_velocity_conversion.cpp)
-# target_link_libraries(test_path_with_velocity_conversion ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  rosidl_get_typesupport_target(cpp_typesupport_target
+    ${PROJECT_NAME} rosidl_typesupport_cpp
+  )
 
-# find_package(roslint REQUIRED)
-# roslint_cpp()
-# roslint_add_test()
-# endif()
+  target_link_libraries(test_path_with_velocity_conversion
+    rclcpp::rclcpp ${geometry_msgs_TARGETS} ${nav_msgs_TARGETS} ${std_msgs_TARGETS} ${cpp_typesupport_target}
+  )
+endif()
 
-# install(DIRECTORY include/${PROJECT_NAME}/
-# DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-# )
 ament_package()

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -1,49 +1,48 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14.4)
 project(trajectory_tracker_msgs)
+
+set(CMAKE_CXX_STANDARD 17)
 
 set(MESSAGE_DEPENDS
   geometry_msgs
   std_msgs
 )
 
-find_package(catkin REQUIRED COMPONENTS message_generation ${MESSAGE_DEPENDS})
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
-add_service_files(
-  FILES
-    ChangePath.srv
+foreach(PKG ${MESSAGE_DEPENDS})
+  find_package(${PKG} REQUIRED)
+endforeach()
+
+rosidl_generate_interfaces(
+  srv/ChangePath.srv
+  msg/PathWithVelocity.msg
+  msg/PoseStampedWithVelocity.msg
+  msg/TrajectoryServerStatus.msg
+  msg/TrajectoryTrackerStatus.msg
+  DEPENDENCIES ${MESSAGE_DEPENDS}
 )
-add_message_files(
-  FILES
-    PathWithVelocity.msg
-    PoseStampedWithVelocity.msg
-    TrajectoryServerStatus.msg
-    TrajectoryTrackerStatus.msg
-)
-generate_messages(DEPENDENCIES ${MESSAGE_DEPENDS})
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS message_runtime ${MESSAGE_DEPENDS}
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+# if(CATKIN_ENABLE_TESTING)
+# set(THREADS_PREFER_PTHREAD_FLAG ON)
+# find_package(Threads REQUIRED)
 
-if(CATKIN_ENABLE_TESTING)
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
+# find_package(roscpp REQUIRED)
+# find_package(rosunit REQUIRED)
 
-  find_package(roscpp REQUIRED)
-  find_package(rosunit REQUIRED)
+# add_compile_options(-std=c++11)
 
-  add_compile_options(-std=c++11)
+# catkin_add_gtest(test_path_with_velocity_conversion test/src/test_path_with_velocity_conversion.cpp)
+# target_link_libraries(test_path_with_velocity_conversion ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-  catkin_add_gtest(test_path_with_velocity_conversion test/src/test_path_with_velocity_conversion.cpp)
-  target_link_libraries(test_path_with_velocity_conversion ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+# find_package(roslint REQUIRED)
+# roslint_cpp()
+# roslint_add_test()
+# endif()
 
-  find_package(roslint REQUIRED)
-  roslint_cpp()
-  roslint_add_test()
-endif()
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+# install(DIRECTORY include/${PROJECT_NAME}/
+# DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+# )
+ament_package()

--- a/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h
+++ b/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h
@@ -30,22 +30,22 @@
 #ifndef TRAJECTORY_TRACKER_MSGS_CONVERTER_H
 #define TRAJECTORY_TRACKER_MSGS_CONVERTER_H
 
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Vector3.h>
-#include <nav_msgs/Path.h>
-#include <trajectory_tracker_msgs/PathWithVelocity.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <trajectory_tracker_msgs/msg/path_with_velocity.hpp>
 
-namespace trajectory_tracker_msgs
+namespace trajectory_tracker_msgs::msg
 {
 inline PathWithVelocity toPathWithVelocity(
-    const nav_msgs::Path& src,
+    const nav_msgs::msg::Path& src,
     const double vel)
 {
   PathWithVelocity dest;
   dest.header = src.header;
   dest.poses.clear();
   dest.poses.reserve(src.poses.size());
-  for (const geometry_msgs::PoseStamped& p : src.poses)
+  for (const geometry_msgs::msg::PoseStamped& p : src.poses)
   {
     PoseStampedWithVelocity pv;
     pv.header = p.header;
@@ -56,14 +56,14 @@ inline PathWithVelocity toPathWithVelocity(
   return dest;
 }
 inline PathWithVelocity toPathWithVelocity(
-    const nav_msgs::Path& src,
-    const geometry_msgs::Vector3& vel)
+    const nav_msgs::msg::Path& src,
+    const geometry_msgs::msg::Vector3& vel)
 {
   PathWithVelocity dest;
   dest.header = src.header;
   dest.poses.clear();
   dest.poses.reserve(src.poses.size());
-  for (const geometry_msgs::PoseStamped& p : src.poses)
+  for (const geometry_msgs::msg::PoseStamped& p : src.poses)
   {
     PoseStampedWithVelocity pv;
     pv.header = p.header;

--- a/trajectory_tracker_msgs/msg/PathWithVelocity.msg
+++ b/trajectory_tracker_msgs/msg/PathWithVelocity.msg
@@ -1,2 +1,2 @@
-Header header
+std_msgs/Header header
 trajectory_tracker_msgs/PoseStampedWithVelocity[] poses

--- a/trajectory_tracker_msgs/msg/PathWithVelocity.msg
+++ b/trajectory_tracker_msgs/msg/PathWithVelocity.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-trajectory_tracker_msgs/PoseStampedWithVelocity[] poses
+PoseStampedWithVelocity[] poses

--- a/trajectory_tracker_msgs/msg/PathWithVelocity.msg
+++ b/trajectory_tracker_msgs/msg/PathWithVelocity.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-PoseStampedWithVelocity[] poses
+trajectory_tracker_msgs/PoseStampedWithVelocity[] poses

--- a/trajectory_tracker_msgs/msg/TrajectoryServerStatus.msg
+++ b/trajectory_tracker_msgs/msg/TrajectoryServerStatus.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 string filename
 int32 id
 

--- a/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
+++ b/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
@@ -3,7 +3,7 @@ byte FAR_FROM_PATH = 1
 byte FOLLOWING = 2
 byte GOAL = 3
 
-Header header
+std_msgs/Header header
 float32 distance_remains
 float32 angle_remains
 int32 status

--- a/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
+++ b/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
@@ -7,4 +7,4 @@ std_msgs/Header header
 float32 distance_remains
 float32 angle_remains
 int32 status
-Header path_header
+std_msgs/Header path_header

--- a/trajectory_tracker_msgs/package.xml
+++ b/trajectory_tracker_msgs/package.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>trajectory_tracker_msgs</name>
-  <version>0.14.0</version>
+  <version>0.1.0</version>
   <description>Message definitions for trajectory_tracker package</description>
 
-  <maintainer email="atsushi.w@ieee.org">Atsushi Watanabe</maintainer>
+  <maintainer email="tomohiro.oku2023@gmail.com">Tomohiro Oku</maintainer>
   <license>BSD</license>
   <author email="atsushi.w@ieee.org">Atsushi Watanabe</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <test_depend>nav_msgs</test_depend>
-  <test_depend>roscpp</test_depend>
-  <test_depend>roslint</test_depend>
-  <test_depend>rosunit</test_depend>
-
+  <!-- <depend>nav_msgs</depend> -->
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/trajectory_tracker_msgs/package.xml
+++ b/trajectory_tracker_msgs/package.xml
@@ -13,7 +13,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <!-- <depend>nav_msgs</depend> -->
+  <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
 

--- a/trajectory_tracker_msgs/package.xml
+++ b/trajectory_tracker_msgs/package.xml
@@ -13,9 +13,14 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <depend>nav_msgs</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>nav_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/trajectory_tracker_msgs/package.xml
+++ b/trajectory_tracker_msgs/package.xml
@@ -13,14 +13,14 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <depend>std_msgs</depend>
-  <depend>geometry_msgs</depend>
-
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>nav_msgs</test_depend>
+  <test_depend>rclcpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rclcpp</test_depend>
-  <test_depend>nav_msgs</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/trajectory_tracker_msgs/srv/ChangePath.srv
+++ b/trajectory_tracker_msgs/srv/ChangePath.srv
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 string filename
 int32 id
 ---

--- a/trajectory_tracker_msgs/test/src/test_path_with_velocity_conversion.cpp
+++ b/trajectory_tracker_msgs/test/src/test_path_with_velocity_conversion.cpp
@@ -29,20 +29,21 @@
 
 #include <gtest/gtest.h>
 
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Vector3.h>
-#include <nav_msgs/Path.h>
-#include <trajectory_tracker_msgs/PathWithVelocity.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <trajectory_tracker_msgs/msg/path_with_velocity.hpp>
+#include <rclcpp/time.hpp>
 
 #include <trajectory_tracker_msgs/converter.h>
 
 namespace
 {
-nav_msgs::Path generatePath()
+nav_msgs::msg::Path generatePath()
 {
-  nav_msgs::Path path;
+  nav_msgs::msg::Path path;
   path.header.frame_id = "frame-name";
-  path.header.stamp = ros::Time(1234.5);
+  path.header.stamp = rclcpp::Time(1234.5);
   path.poses.resize(2);
   path.poses[0].pose.orientation.w = 1.0;
   path.poses[0].pose.position.x = 2.0;
@@ -53,12 +54,12 @@ nav_msgs::Path generatePath()
   return path;
 }
 
-geometry_msgs::Vector3 generateVector3(
+geometry_msgs::msg::Vector3 generateVector3(
     const double x,
     const double y,
     const double z)
 {
-  geometry_msgs::Vector3 vec;
+  geometry_msgs::msg::Vector3 vec;
   vec.x = x;
   vec.y = y;
   vec.z = z;
@@ -68,9 +69,9 @@ geometry_msgs::Vector3 generateVector3(
 
 TEST(Converter, ToPathWithVelocityScalar)
 {
-  const nav_msgs::Path in = generatePath();
-  const trajectory_tracker_msgs::PathWithVelocity out =
-      trajectory_tracker_msgs::toPathWithVelocity(in, 1.23);
+  const nav_msgs::msg::Path in = generatePath();
+  const trajectory_tracker_msgs::msg::PathWithVelocity out =
+      trajectory_tracker_msgs::msg::toPathWithVelocity(in, 1.23);
 
   ASSERT_EQ(in.header.frame_id, out.header.frame_id);
   ASSERT_EQ(in.header.stamp, out.header.stamp);
@@ -93,10 +94,10 @@ TEST(Converter, ToPathWithVelocityScalar)
 
 TEST(Converter, ToPathWithVelocityVector)
 {
-  const nav_msgs::Path in = generatePath();
-  const geometry_msgs::Vector3 vel = generateVector3(1.23, 0.12, 0.23);
-  const trajectory_tracker_msgs::PathWithVelocity out =
-      trajectory_tracker_msgs::toPathWithVelocity(in, vel);
+  const nav_msgs::msg::Path in = generatePath();
+  const geometry_msgs::msg::Vector3 vel = generateVector3(1.23, 0.12, 0.23);
+  const trajectory_tracker_msgs::msg::PathWithVelocity out =
+      trajectory_tracker_msgs::msg::toPathWithVelocity(in, vel);
 
   ASSERT_EQ(in.header.frame_id, out.header.frame_id);
   ASSERT_EQ(in.header.stamp, out.header.stamp);


### PR DESCRIPTION
## Issues

- Closed #8

## Features

### Message files

- Add namespace for `std_msgs/Header`

### Source files

- Update headers
- Update namespaces of interfaces
- Migrate `ros::Time` to `rclcpp::Time`

### package.xml

- Update dependencies
- Update format to 3 (necessary for `member_of_group` tag)
- Replace maintainer with me
- Reset version to 0.1.0

### CMakeLists.txt

- Update CMake requirements to 3.14.4 (REP-2000)
- Use C++17 to build interface
- Migrate catkin manner to colcon/ament one
- Add `rosidl_typesupport_cpp` to use messages within the package (as `colcon test`)

## Tests

- [x] colcon build
- [x] colcon test (gtest)

<details> <summary>stdout.log</summary>

```log
UpdateCTestConfiguration  from :/root/neonav/build/trajectory_tracker_msgs/CTestConfiguration.ini
Parse Config file:/root/neonav/build/trajectory_tracker_msgs/CTestConfiguration.ini
   Site: danchon
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20250725-1504 - Experimental
UpdateCTestConfiguration  from :/root/neonav/build/trajectory_tracker_msgs/CTestConfiguration.ini
Parse Config file:/root/neonav/build/trajectory_tracker_msgs/CTestConfiguration.ini
Test project /root/neonav/build/trajectory_tracker_msgs
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_path_with_velocity_conversion

1: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/test_path_with_velocity_conversion.gtest.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_cmake_gtest/test_path_with_velocity_conversion.txt" "--command" "/root/neonav/build/trajectory_tracker_msgs/test_path_with_velocity_conversion" "--gtest_output=xml:/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/test_path_with_velocity_conversion.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/root/neonav/build/trajectory_tracker_msgs':
1:  - /root/neonav/build/trajectory_tracker_msgs/test_path_with_velocity_conversion --gtest_output=xml:/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/test_path_with_velocity_conversion.gtest.xml
1: [==========] Running 2 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 2 tests from Converter
1: [ RUN      ] Converter.ToPathWithVelocityScalar
1: [       OK ] Converter.ToPathWithVelocityScalar (0 ms)
1: [ RUN      ] Converter.ToPathWithVelocityVector
1: [       OK ] Converter.ToPathWithVelocityVector (0 ms)
1: [----------] 2 tests from Converter (0 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 2 tests from 1 test suite ran. (0 ms total)
1: [  PASSED  ] 2 tests.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/test_path_with_velocity_conversion.gtest.xml'
1: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/test_path_with_velocity_conversion.gtest.xml'
1/7 Test #1: test_path_with_velocity_conversion ...   Passed    0.09 sec
test 2
    Start 2: copyright

2: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/copyright.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_copyright/copyright.txt" "--command" "/opt/ros/humble/bin/ament_copyright" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/copyright.xunit.xml"
2: Test timeout computed to be: 200
2: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
2:  - /opt/ros/humble/bin/ament_copyright --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/copyright.xunit.xml
2: include/trajectory_tracker_msgs/converter.h: could not find copyright notice
2: test/src/test_path_with_velocity_conversion.cpp: could not find copyright notice
2: 2 errors, checked 2 files
2: -- run_test.py: return code 1
2: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/copyright.xunit.xml'
2/7 Test #2: copyright ............................***Failed    0.20 sec
test 3
    Start 3: cppcheck

3: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cppcheck.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_cppcheck/cppcheck.txt" "--command" "/opt/ros/humble/bin/ament_cppcheck" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cppcheck.xunit.xml" "--include_dirs" "/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include"
3: Test timeout computed to be: 300
3: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
3:  - /opt/ros/humble/bin/ament_cppcheck --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cppcheck.xunit.xml --include_dirs /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include
3: cppcheck 2.7 has known performance issues and therefore will not be used, set the AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS environment variable to override this.
3: -- run_test.py: return code 0
3: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cppcheck.xunit.xml'
3/7 Test #3: cppcheck .............................   Passed    0.18 sec
test 4
    Start 4: cpplint

4: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cpplint.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_cpplint/cpplint.txt" "--command" "/opt/ros/humble/bin/ament_cpplint" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cpplint.xunit.xml"
4: Test timeout computed to be: 120
4: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
4:  - /opt/ros/humble/bin/ament_cpplint --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cpplint.xunit.xml
4: /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h:30:  #ifndef header guard has wrong style, please use: TRAJECTORY_TRACKER_MSGS__CONVERTER_H_  [build/header_guard] [5]
4: /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h:78:  #endif line should be "#endif  // TRAJECTORY_TRACKER_MSGS__CONVERTER_H_"  [build/header_guard] [5]
4: /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h:76:  Namespace should be terminated with "// namespace trajectory_tracker_msgs::msg"  [readability/namespace] [5]
4: /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/test/src/test_path_with_velocity_conversion.cpp:38:  Found C system header after other header. Should be: test_path_with_velocity_conversion.h, c system, c++ system, other.  [build/include_order] [4]
4: Category 'build/header_guard' errors found: 2
4: Category 'build/include_order' errors found: 1
4: Category 'readability/namespace' errors found: 1
4: Total errors found: 4
4: Using '--root=/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include' argument
4: 
4: Done processing /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/include/trajectory_tracker_msgs/converter.h
4: 
4: Using '--root=/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/test/src' argument
4: 
4: Done processing /root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs/test/src/test_path_with_velocity_conversion.cpp
4: 
4: -- run_test.py: return code 1
4: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/cpplint.xunit.xml'
4/7 Test #4: cpplint ..............................***Failed    0.23 sec
test 5
    Start 5: lint_cmake

5: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/lint_cmake.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_lint_cmake/lint_cmake.txt" "--command" "/opt/ros/humble/bin/ament_lint_cmake" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/lint_cmake.xunit.xml"
5: Test timeout computed to be: 60
5: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
5:  - /opt/ros/humble/bin/ament_lint_cmake --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/lint_cmake.xunit.xml
5: CMakeLists.txt:33: Extra spaces between 'if' and its () [whitespace/extra]
5: CMakeLists.txt:39: Line ends in whitespace [whitespace/eol]
5: CMakeLists.txt:42: Line ends in whitespace [whitespace/eol]
5: 
5: 
5: 3 errors
5: -- run_test.py: return code 1
5: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/lint_cmake.xunit.xml'
5/7 Test #5: lint_cmake ...........................***Failed    0.16 sec
test 6
    Start 6: uncrustify

6: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/uncrustify.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_uncrustify/uncrustify.txt" "--command" "/opt/ros/humble/bin/ament_uncrustify" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/uncrustify.xunit.xml"
6: Test timeout computed to be: 60
6: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
6:  - /opt/ros/humble/bin/ament_uncrustify --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/uncrustify.xunit.xml
6: Code style divergence in file 'include/trajectory_tracker_msgs/converter.h':
6: 
6: --- include/trajectory_tracker_msgs/converter.h
6: +++ include/trajectory_tracker_msgs/converter.h.uncrustify
6: @@ -40,2 +40,2 @@
6: -inline PathWithVelocity toPathWithVelocity(
6: -    const nav_msgs::msg::Path& src,
6: +  inline PathWithVelocity toPathWithVelocity(
6: +    const nav_msgs::msg::Path & src,
6: @@ -43,6 +42,0 @@
6: -{
6: -  PathWithVelocity dest;
6: -  dest.header = src.header;
6: -  dest.poses.clear();
6: -  dest.poses.reserve(src.poses.size());
6: -  for (const geometry_msgs::msg::PoseStamped& p : src.poses)
6: @@ -50,5 +44,12 @@
6: -    PoseStampedWithVelocity pv;
6: -    pv.header = p.header;
6: -    pv.pose = p.pose;
6: -    pv.linear_velocity.x = vel;
6: -    dest.poses.push_back(pv);
6: +    PathWithVelocity dest;
6: +    dest.header = src.header;
6: +    dest.poses.clear();
6: +    dest.poses.reserve(src.poses.size());
6: +    for (const geometry_msgs::msg::PoseStamped & p : src.poses) {
6: +      PoseStampedWithVelocity pv;
6: +      pv.header = p.header;
6: +      pv.pose = p.pose;
6: +      pv.linear_velocity.x = vel;
6: +      dest.poses.push_back(pv);
6: +    }
6: +    return dest;
6: @@ -56,11 +57,3 @@
6: -  return dest;
6: -}
6: -inline PathWithVelocity toPathWithVelocity(
6: -    const nav_msgs::msg::Path& src,
6: -    const geometry_msgs::msg::Vector3& vel)
6: -{
6: -  PathWithVelocity dest;
6: -  dest.header = src.header;
6: -  dest.poses.clear();
6: -  dest.poses.reserve(src.poses.size());
6: -  for (const geometry_msgs::msg::PoseStamped& p : src.poses)
6: +  inline PathWithVelocity toPathWithVelocity(
6: +    const nav_msgs::msg::Path & src,
6: +    const geometry_msgs::msg::Vector3 & vel)
6: @@ -68,5 +61,12 @@
6: -    PoseStampedWithVelocity pv;
6: -    pv.header = p.header;
6: -    pv.pose = p.pose;
6: -    pv.linear_velocity = vel;
6: -    dest.poses.push_back(pv);
6: +    PathWithVelocity dest;
6: +    dest.header = src.header;
6: +    dest.poses.clear();
6: +    dest.poses.reserve(src.poses.size());
6: +    for (const geometry_msgs::msg::PoseStamped & p : src.poses) {
6: +      PoseStampedWithVelocity pv;
6: +      pv.header = p.header;
6: +      pv.pose = p.pose;
6: +      pv.linear_velocity = vel;
6: +      dest.poses.push_back(pv);
6: +    }
6: +    return dest;
6: @@ -74,2 +73,0 @@
6: -  return dest;
6: -}
6: 
6: Code style divergence in file 'test/src/test_path_with_velocity_conversion.cpp':
6: 
6: --- test/src/test_path_with_velocity_conversion.cpp
6: +++ test/src/test_path_with_velocity_conversion.cpp.uncrustify
6: @@ -58,3 +58,3 @@
6: -    const double x,
6: -    const double y,
6: -    const double z)
6: +  const double x,
6: +  const double y,
6: +  const double z)
6: @@ -74 +74 @@
6: -      trajectory_tracker_msgs::msg::toPathWithVelocity(in, 1.23);
6: +    trajectory_tracker_msgs::msg::toPathWithVelocity(in, 1.23);
6: @@ -78,2 +78 @@
6: -  for (size_t i = 0; i < in.poses.size(); ++i)
6: -  {
6: +  for (size_t i = 0; i < in.poses.size(); ++i) {
6: @@ -100 +99 @@
6: -      trajectory_tracker_msgs::msg::toPathWithVelocity(in, vel);
6: +    trajectory_tracker_msgs::msg::toPathWithVelocity(in, vel);
6: @@ -104,2 +103 @@
6: -  for (size_t i = 0; i < in.poses.size(); ++i)
6: -  {
6: +  for (size_t i = 0; i < in.poses.size(); ++i) {
6: @@ -121 +119 @@
6: -int main(int argc, char** argv)
6: +int main(int argc, char ** argv)
6: 
6: 2 files with code style divergence
6: -- run_test.py: return code 1
6: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/uncrustify.xunit.xml'
6/7 Test #6: uncrustify ...........................***Failed    0.20 sec
test 7
    Start 7: xmllint

7: Test command: /usr/bin/python3.10 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/xmllint.xunit.xml" "--package-name" "trajectory_tracker_msgs" "--output-file" "/root/neonav/build/trajectory_tracker_msgs/ament_xmllint/xmllint.txt" "--command" "/opt/ros/humble/bin/ament_xmllint" "--xunit-file" "/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/xmllint.xunit.xml"
7: Test timeout computed to be: 60
7: -- run_test.py: invoking following command in '/root/neonav/src/neonavigation_msgs/trajectory_tracker_msgs':
7:  - /opt/ros/humble/bin/ament_xmllint --xunit-file /root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/xmllint.xunit.xml
7: File 'package.xml' is valid
7: 
7: No problems found
7: -- run_test.py: return code 0
7: -- run_test.py: verify result file '/root/neonav/build/trajectory_tracker_msgs/test_results/trajectory_tracker_msgs/xmllint.xunit.xml'
7/7 Test #7: xmllint ..............................   Passed    0.17 sec

43% tests passed[0;0m, [0;31m4 tests failed[0;0m out of 7

Label Time Summary:
copyright     =   0.20 sec*proc (1 test)
cppcheck      =   0.18 sec*proc (1 test)
cpplint       =   0.23 sec*proc (1 test)
gtest         =   0.09 sec*proc (1 test)
lint_cmake    =   0.16 sec*proc (1 test)
linter        =   1.14 sec*proc (6 tests)
uncrustify    =   0.20 sec*proc (1 test)
xmllint       =   0.17 sec*proc (1 test)

Total Test time (real) =   1.24 sec

The following tests FAILED:
	[0;31m  2 - copyright (Failed)[0;0m
	[0;31m  4 - cpplint (Failed)[0;0m
	[0;31m  5 - lint_cmake (Failed)[0;0m
	[0;31m  6 - uncrustify (Failed)[0;0m
```

</details>

## References

- https://docs.ros.org/en/humble/How-To-Guides/Migrating-from-ROS1/Migrating-CPP-Packages.html
- https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.html#link-against-the-interface
