### PR TITLE
[minimum migration] safety_limiter_msgs

### DIFF
--- a/safety_limiter_msgs/CMakeLists.txt
+++ b/safety_limiter_msgs/CMakeLists.txt
@@ -1,23 +1,18 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.14.4)
 project(safety_limiter_msgs)
 
-find_package(catkin REQUIRED COMPONENTS
-  message_generation
-  std_msgs
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/SafetyLimiterStatus.msg
+  DEPENDENCIES std_msgs builtin_interfaces
 )
 
-add_message_files(
-  FILES
-    SafetyLimiterStatus.msg
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-generate_messages(
-  DEPENDENCIES
-    std_msgs
-)
-
-catkin_package(
-  CATKIN_DEPENDS
-    message_runtime
-    std_msgs
-)
+ament_package()

--- a/safety_limiter_msgs/msg/SafetyLimiterStatus.msg
+++ b/safety_limiter_msgs/msg/SafetyLimiterStatus.msg
@@ -1,6 +1,6 @@
-Header header
+std_msgs/Header header
 
 float64 limit_ratio
 bool is_cloud_available
 bool has_watchdog_timed_out
-time stuck_started_since # Non-zero if the robot is stuck.
+builtin_interfaces/Time stuck_started_since # Non-zero if the robot is stuck.

--- a/safety_limiter_msgs/package.xml
+++ b/safety_limiter_msgs/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>std_msgs</depend>
+  <depend>builtin_interfaces</depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/safety_limiter_msgs/package.xml
+++ b/safety_limiter_msgs/package.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>safety_limiter_msgs</name>
-  <version>0.14.0</version>
+  <version>0.1.0</version>
   <description>Message definitions for safety_limiter_msgs package</description>
 
-  <maintainer email="atsushi.w@ieee.org">Atsushi Watanabe</maintainer>
+  <maintainer email="tomohiro.oku2023@gmail.com">Tomohiro Oku</maintainer>
   <license>BSD</license>
   <author email="daikimaekawa29@gmail.com">Daiki Maekawa</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>std_msgs</depend>
 
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Fixes ok-tmhr/neonavigation_msgs#10

## Features

- #9

## Tests

- [x] colcon build

```sh
ros2 interface show safety_limiter_msgs/msg/SafetyLimiterStatus 
std_msgs/Header header
        builtin_interfaces/Time stamp
                int32 sec
                uint32 nanosec
        string frame_id

float64 limit_ratio
bool is_cloud_available
bool has_watchdog_timed_out
builtin_interfaces/Time stuck_started_since # Non-zero if the robot is stuck.
        int32 sec
        uint32 nanosec
```