### PR TITLE
[minimum migration] neonavigation_metrics_msgs

### DIFF
--- a/neonavigation_metrics_msgs/CMakeLists.txt
+++ b/neonavigation_metrics_msgs/CMakeLists.txt
@@ -1,37 +1,46 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.14.4)
 project(neonavigation_metrics_msgs)
+
+set(CMAKE_CXX_STANDARD 17)
 
 set(MESSAGE_DEPENDS
   std_msgs
 )
 
-find_package(catkin REQUIRED COMPONENTS message_generation ${MESSAGE_DEPENDS})
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+foreach(PACKAGE ${MESSAGE_DEPENDS})
+  find_package(${PACKAGE} REQUIRED)
+endforeach()
 
-add_message_files(
-  FILES
-    Metric.msg
-    Metrics.msg
+rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/Metric.msg
+  msg/Metrics.msg
+  DEPENDENCIES ${MESSAGE_DEPENDS}
 )
-generate_messages(DEPENDENCIES ${MESSAGE_DEPENDS})
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS message_runtime ${MESSAGE_DEPENDS}
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+if(BUILD_TESTING)
 
-if(CATKIN_ENABLE_TESTING)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_helper test/src/test_helper.cpp)
+  target_include_directories(test_helper PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  rosidl_get_typesupport_target(cpp_typesupport_target
+    ${PROJECT_NAME} rosidl_typesupport_cpp
+  )
+  target_link_libraries(test_helper ${cpp_typesupport_target})
 
-  catkin_add_gtest(test_helper test/src/test_helper.cpp)
-  target_link_libraries(test_helper ${catkin_LIBRARIES})
-
-  find_package(roslint REQUIRED)
-  roslint_cpp()
-  roslint_add_test()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
+
+ament_export_include_directories()
+
+ament_package()

--- a/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h
+++ b/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h
@@ -33,10 +33,10 @@
 #include <string>
 #include <utility>
 
-#include <neonavigation_metrics_msgs/Metric.h>
-#include <neonavigation_metrics_msgs/Metrics.h>
+#include <neonavigation_metrics_msgs/msg/metric.hpp>
+#include <neonavigation_metrics_msgs/msg/metrics.hpp>
 
-namespace neonavigation_metrics_msgs
+namespace neonavigation_metrics_msgs::msg
 {
 template <typename... Strings>
 Metric metric(

--- a/neonavigation_metrics_msgs/msg/Metrics.msg
+++ b/neonavigation_metrics_msgs/msg/Metrics.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 Metric[] data

--- a/neonavigation_metrics_msgs/package.xml
+++ b/neonavigation_metrics_msgs/package.xml
@@ -1,20 +1,27 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>neonavigation_metrics_msgs</name>
-  <version>0.14.0</version>
+  <version>0.1.0</version>
   <description>Metrics message definitions for neonavigation meta-package</description>
 
-  <maintainer email="atsushi.w@ieee.org">Atsushi Watanabe</maintainer>
+  <maintainer email="tomohiro.oku2023@gmail.com">Tomohiro Oku</maintainer>
   <license>BSD</license>
   <author email="atsushi.w@ieee.org">Atsushi Watanabe</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <test_depend>roslint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <depend>std_msgs</depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/neonavigation_metrics_msgs/test/src/test_helper.cpp
+++ b/neonavigation_metrics_msgs/test/src/test_helper.cpp
@@ -33,7 +33,7 @@
 
 TEST(Helper, metric)
 {
-  const auto m = neonavigation_metrics_msgs::metric("hoge", 1.23, "x", "tag1", "tag2");
+  const auto m = neonavigation_metrics_msgs::msg::metric("hoge", 1.23, "x", "tag1", "tag2");
   ASSERT_EQ("hoge", m.name);
   ASSERT_EQ(1.23, m.value);
   ASSERT_EQ("x", m.unit);
@@ -44,7 +44,7 @@ TEST(Helper, metric)
 
 TEST(Helper, metricNoTags)
 {
-  const auto m = neonavigation_metrics_msgs::metric("hoge", 1.23, "i");
+  const auto m = neonavigation_metrics_msgs::msg::metric("hoge", 1.23, "i");
   ASSERT_EQ("hoge", m.name);
   ASSERT_EQ(1.23, m.value);
   ASSERT_EQ("i", m.unit);


### PR DESCRIPTION
Fixes ok-tmhr/neonavigation_msgs#13

## Features

- #9

## Tests

- [x] colcon build
- [x] colcon test (gtest)

```sh
$ ros2 interface show neonavigation_metrics_msgs/msg/Metric
string name
float64 value
string unit
string[] tags
```

```sh
$ ros2 interface show neonavigation_metrics_msgs/msg/Metrics
std_msgs/Header header
        builtin_interfaces/Time stamp
                int32 sec
                uint32 nanosec
        string frame_id

Metric[] data
        string name
        float64 value
        string unit
        string[] tags
```

<details><summary>stdout.log</summary>

```log
UpdateCTestConfiguration  from :/workspaces/neonav/build/neonavigation_metrics_msgs/CTestConfiguration.ini
Parse Config file:/workspaces/neonav/build/neonavigation_metrics_msgs/CTestConfiguration.ini
   Site: fb44e04a6cec
   Build name: (empty)
 Add coverage exclude regular expressions.
Create new tag: 20250726-1147 - Experimental
UpdateCTestConfiguration  from :/workspaces/neonav/build/neonavigation_metrics_msgs/CTestConfiguration.ini
Parse Config file:/workspaces/neonav/build/neonavigation_metrics_msgs/CTestConfiguration.ini
Test project /workspaces/neonav/build/neonavigation_metrics_msgs
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: test_helper

1: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/test_helper.gtest.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_cmake_gtest/test_helper.txt" "--command" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_helper" "--gtest_output=xml:/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/test_helper.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/workspaces/neonav/build/neonavigation_metrics_msgs':
1:  - /workspaces/neonav/build/neonavigation_metrics_msgs/test_helper --gtest_output=xml:/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/test_helper.gtest.xml
1: [==========] Running 2 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 2 tests from Helper
1: [ RUN      ] Helper.metric
1: [       OK ] Helper.metric (0 ms)
1: [ RUN      ] Helper.metricNoTags
1: [       OK ] Helper.metricNoTags (0 ms)
1: [----------] 2 tests from Helper (0 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 2 tests from 1 test suite ran. (0 ms total)
1: [  PASSED  ] 2 tests.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/test_helper.gtest.xml'
1: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/test_helper.gtest.xml'
1/7 Test #1: test_helper ......................   Passed    0.05 sec
test 2
    Start 2: copyright

2: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/copyright.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_copyright/copyright.txt" "--command" "/opt/ros/humble/bin/ament_copyright" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/copyright.xunit.xml"
2: Test timeout computed to be: 200
2: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
2:  - /opt/ros/humble/bin/ament_copyright --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/copyright.xunit.xml
2: include/neonavigation_metrics_msgs/helper.h: could not find copyright notice
2: test/src/test_helper.cpp: could not find copyright notice
2: 2 errors, checked 2 files
2: -- run_test.py: return code 1
2: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/copyright.xunit.xml'
2/7 Test #2: copyright ........................***Failed    0.10 sec
test 3
    Start 3: cppcheck

3: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cppcheck.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_cppcheck/cppcheck.txt" "--command" "/opt/ros/humble/bin/ament_cppcheck" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cppcheck.xunit.xml" "--include_dirs" "/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include"
3: Test timeout computed to be: 300
3: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
3:  - /opt/ros/humble/bin/ament_cppcheck --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cppcheck.xunit.xml --include_dirs /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include
3: cppcheck 2.7 has known performance issues and therefore will not be used, set the AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS environment variable to override this.
3: -- run_test.py: return code 0
3: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cppcheck.xunit.xml'
3/7 Test #3: cppcheck .........................   Passed    0.11 sec
test 4
    Start 4: cpplint

4: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cpplint.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_cpplint/cpplint.txt" "--command" "/opt/ros/humble/bin/ament_cpplint" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cpplint.xunit.xml"
4: Test timeout computed to be: 120
4: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
4:  - /opt/ros/humble/bin/ament_cpplint --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cpplint.xunit.xml
4: /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h:30:  #ifndef header guard has wrong style, please use: NEONAVIGATION_METRICS_MSGS__HELPER_H_  [build/header_guard] [5]
4: /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h:57:  #endif line should be "#endif  // NEONAVIGATION_METRICS_MSGS__HELPER_H_"  [build/header_guard] [5]
4: /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h:55:  Namespace should be terminated with "// namespace neonavigation_metrics_msgs::msg"  [readability/namespace] [5]
4: Category 'build/header_guard' errors found: 2
4: Category 'readability/namespace' errors found: 1
4: Total errors found: 3
4: Using '--root=/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include' argument
4: 
4: Done processing /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/include/neonavigation_metrics_msgs/helper.h
4: 
4: Using '--root=/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/test/src' argument
4: 
4: Done processing /workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs/test/src/test_helper.cpp
4: 
4: -- run_test.py: return code 1
4: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/cpplint.xunit.xml'
4/7 Test #4: cpplint ..........................***Failed    0.11 sec
test 5
    Start 5: lint_cmake

5: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/lint_cmake.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_lint_cmake/lint_cmake.txt" "--command" "/opt/ros/humble/bin/ament_lint_cmake" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/lint_cmake.xunit.xml"
5: Test timeout computed to be: 60
5: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
5:  - /opt/ros/humble/bin/ament_lint_cmake --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/lint_cmake.xunit.xml
5: 
5: No problems found
5: -- run_test.py: return code 0
5: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/lint_cmake.xunit.xml'
5/7 Test #5: lint_cmake .......................   Passed    0.08 sec
test 6
    Start 6: uncrustify

6: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/uncrustify.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_uncrustify/uncrustify.txt" "--command" "/opt/ros/humble/bin/ament_uncrustify" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/uncrustify.xunit.xml"
6: Test timeout computed to be: 60
6: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
6:  - /opt/ros/humble/bin/ament_uncrustify --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/uncrustify.xunit.xml
6: Code style divergence in file 'include/neonavigation_metrics_msgs/helper.h':
6: 
6: --- include/neonavigation_metrics_msgs/helper.h
6: +++ include/neonavigation_metrics_msgs/helper.h.uncrustify
6: @@ -41,3 +41,3 @@
6: -template <typename... Strings>
6: -Metric metric(
6: -    const std::string& name,
6: +  template < typename ... Strings >
6: +  Metric metric(
6: +    const std::string & name,
6: @@ -45,10 +45,10 @@
6: -    const std::string& unit,
6: -    Strings&&... tags)
6: -{
6: -  Metric out;
6: -  out.name = name;
6: -  out.value = value;
6: -  out.unit = unit;
6: -  (out.tags.push_back(std::forward<Strings>(tags)), ...);
6: -  return out;
6: -}
6: +    const std::string & unit,
6: +    Strings &&... tags)
6: +  {
6: +    Metric out;
6: +    out.name = name;
6: +    out.value = value;
6: +    out.unit = unit;
6: +    (out.tags.push_back(std::forward < Strings > (tags)), ...);
6: +    return out;
6: +  }
6: 
6: Code style divergence in file 'test/src/test_helper.cpp':
6: 
6: --- test/src/test_helper.cpp
6: +++ test/src/test_helper.cpp.uncrustify
6: @@ -54 +54 @@
6: -int main(int argc, char** argv)
6: +int main(int argc, char ** argv)
6: 
6: 2 files with code style divergence
6: -- run_test.py: return code 1
6: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/uncrustify.xunit.xml'
6/7 Test #6: uncrustify .......................***Failed    0.10 sec
test 7
    Start 7: xmllint

7: Test command: /usr/bin/python3 "-u" "/opt/ros/humble/share/ament_cmake_test/cmake/run_test.py" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/xmllint.xunit.xml" "--package-name" "neonavigation_metrics_msgs" "--output-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/ament_xmllint/xmllint.txt" "--command" "/opt/ros/humble/bin/ament_xmllint" "--xunit-file" "/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/xmllint.xunit.xml"
7: Test timeout computed to be: 60
7: -- run_test.py: invoking following command in '/workspaces/neonav/src/neonavigation_msgs/neonavigation_metrics_msgs':
7:  - /opt/ros/humble/bin/ament_xmllint --xunit-file /workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/xmllint.xunit.xml
7: File 'package.xml' is valid
7: 
7: No problems found
7: -- run_test.py: return code 0
7: -- run_test.py: verify result file '/workspaces/neonav/build/neonavigation_metrics_msgs/test_results/neonavigation_metrics_msgs/xmllint.xunit.xml'
7/7 Test #7: xmllint ..........................   Passed    0.09 sec

57% tests passed[0;0m, [0;31m3 tests failed[0;0m out of 7

Label Time Summary:
copyright     =   0.10 sec*proc (1 test)
cppcheck      =   0.11 sec*proc (1 test)
cpplint       =   0.11 sec*proc (1 test)
gtest         =   0.05 sec*proc (1 test)
lint_cmake    =   0.08 sec*proc (1 test)
linter        =   0.59 sec*proc (6 tests)
uncrustify    =   0.10 sec*proc (1 test)
xmllint       =   0.09 sec*proc (1 test)

Total Test time (real) =   0.64 sec

The following tests FAILED:
	[0;31m  2 - copyright (Failed)[0;0m
	[0;31m  4 - cpplint (Failed)[0;0m
	[0;31m  6 - uncrustify (Failed)[0;0m
```

</details>
